### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/packages/plugin/repo/src/contributors/parse.ts
+++ b/packages/plugin/repo/src/contributors/parse.ts
@@ -5,15 +5,20 @@ import type {
 import type { PackageJSON } from '@dovenv/core/utils'
 
 const extractGithubUsername = ( input: string ): string => {
-
-	if ( input.includes( 'github.com' ) ) {
-
-		const match = input.match( /github\.com\/([^/]+)/ )
-		return match ? match[1] : 'unknown'
-
-	}
-	return input.split( '@' )[0] || 'unknown'
-
+    try {
+        const url = new URL(input);
+        if (url.hostname === 'github.com') {
+            const match = url.pathname.match( /\/([^/]+)/ );
+            return match ? match[1] : 'unknown';
+        }
+    } catch (e) {
+        // If input is not a valid URL, fall back to the original logic
+        if (input.includes('github.com')) {
+            const match = input.match(/github\.com\/([^/]+)/);
+            return match ? match[1] : 'unknown';
+        }
+    }
+    return input.split('@')[0] || 'unknown';
 }
 
 export const package2Contributors = ( pkg: PackageJSON ): {


### PR DESCRIPTION
Potential fix for [https://github.com/pigeonposse/dovenv/security/code-scanning/7](https://github.com/pigeonposse/dovenv/security/code-scanning/7)

To fix the problem, we need to parse the URL and check the host component specifically, rather than checking if 'github.com' is a substring of the entire URL. This ensures that 'github.com' is correctly identified as the host and not part of another component of the URL.

The best way to fix this is to use the `URL` class available in modern JavaScript environments to parse the URL and then check the `hostname` property. This change should be made in the `extractGithubUsername` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
